### PR TITLE
Add OBSD LaunchPad MCP — free token deployment for AI agents on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[Heurist Mesh Agent](https://github.com/heurist-network/heurist-mesh-mcp-server)** - Access specialized web3 AI agents for blockchain analysis, smart contract security, token metrics, and blockchain interactions through the [Heurist Mesh network](https://github.com/heurist-network/heurist-agent-framework/tree/main/mesh).
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
+- **[OBSD LaunchPad MCP](https://github.com/thryxagi/obsd-launchpad)** - Full token lifecycle MCP for AI agents on [Base](https://base.org). 12 tools: deploy, buy, sell, claim fees, get quotes, referral program, and query earnings via `npx obsd-launchpad-mcp`. Treasury-backed intrinsic value floor, progressive sell tax, and 37.5% passive OBSD income. 10 verified contracts, 275 tests.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
 
 ---


### PR DESCRIPTION
## OBSD LaunchPad MCP Server (v1.0.3)

Adds [OBSD LaunchPad](https://github.com/thryxagi/obsd-launchpad) to the Server Implementations list.

### What it does
Full token lifecycle MCP for AI agents on Base. 10 tools covering deploy, trade, and analytics.

### Install
```
npx -y obsd-launchpad-mcp
```

### 10 Tools
```
launch_token("My Token", "MTK", "0xWallet")  — Deploy a token
buy_token("0xToken", "0.001")                 — Buy with ETH
sell_token("0xToken", "1000")                 — Sell for ETH
claim_fees("0xToken")                         — Distribute pending fees
quote_buy("0xToken", "0.001")                 — Get buy quote
quote_sell("0xToken", "1000")                 — Get sell quote
get_creator_earnings("0xWallet")              — Lifetime OBSD earned
get_platform_stats()                          — Platform overview
get_token_info("0xToken")                     — Token details
list_launches()                               — All launched tokens
```

### Key Features
- **Free** — pool seeded with 10K OBSD at deployment
- **Passive income** — creator earns 37.5% of all swap fees in OBSD forever
- **Anti-rug** — zero token allocation to creator, LP burned, immutable contracts
- **Floor price** — treasury-backed intrinsic value that mathematically only rises
- **Battle tested** — 10 verified contracts on Base mainnet, 275 Foundry tests

### Links
- npm: `obsd-launchpad-mcp`
- GitHub: https://github.com/thryxagi/obsd-launchpad
- LaunchPad contract: `0x1e789ddf62554769c5D5Aab57FAB32613bf3d78b` (Base)