### PR TITLE
Add bitcoin-mcp — 49 tools for Bitcoin AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp)** - The most comprehensive Bitcoin MCP server — 43 tools for fees, mempool, blocks, transactions, mining, price, and supply. Zero config, works with any MCP client. First Bitcoin MCP on the [official Anthropic registry](https://github.com/modelcontextprotocol/servers).
 
 ---
 


### PR DESCRIPTION
Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) — the most comprehensive Bitcoin MCP server.

49 tools for Bitcoin data: fee intelligence (send-or-wait verdicts), mempool analysis, block/transaction data, mining pool rankings, BTC price, supply/halving, BOLT11 decoding, address balance/history, and more.

Zero config — works instantly with the free hosted Satoshi API, or connect your own Bitcoin Core node.

PyPI: `pip install bitcoin-mcp`