### PR TITLE
Add Sovereign Agent Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[Sovereign Agent Chain](https://github.com/ElromEvedElElyon/sovereign-agent-chain)** - Bitcoin-native AI agent marketplace with AGT meta-protocol on OP_RETURN. 32 MCP tools for PSBT wallet bridge, cross-chain swaps (BTC/SOL/ETH/Runes), agent registry, reputation system, and escrow. 258 tests.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [Sovereign Agent Chain](https://github.com/ElromEvedElElyon/sovereign-agent-chain) to the Server Implementations list
- Bitcoin-native AI agent marketplace with AGT meta-protocol on OP_RETURN
- 32 MCP tools: PSBT wallet bridge, cross-chain swaps (BTC/SOL/ETH/Runes), agent registry, reputation system, and escrow
- 258 tests, fully open source