### PR TITLE
Add Lightyear CryptoPunks MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server)** - Providing latest cryptocurrency news to AI agents, powered by CryptoPanic.
 - **[Dappier](https://github.com/DappierAI/dappier-mcp)** - Connect LLMs to real-time, rights-cleared, proprietary data from trusted sources. Access specialized models for Real-Time Web Search, News, Sports, Financial Data, Crypto, and premium publisher content. Explore data models at [marketplace.dappier.com](https://marketplace.dappier.com/marketplace).
 - **[DexPaprika](https://github.com/coinpaprika/dexpaprika-mcp)** - Access real-time data for over 5 million tokens across 20+ blockchain networks including Solana, Base, BSC, and Ethereum. Get token prices, liquidity pool information, historical data and DEX analytics. Full documentation for developers [DexPaprika Docs](https://docs.dexpaprika.com/introduction)
+- **[Lightyear CryptoPunks](https://punks.lightyear.build)** - Browse traits, filter 10K punks, real-time marketplace listings, bid depth, Merkle root computation, and AI-assisted bid pricing for the native CryptoPunks marketplace. 11 tools, Streamable HTTP remote server at [punks.lightyear.build/api/mcp](https://punks.lightyear.build/api/mcp). Free, no API key.
 - **[whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp)**  -  A mcp server for tracking cryptocurrency whale transactions.
 - **[Heurist Mesh Agent](https://github.com/heurist-network/heurist-mesh-mcp-server)** - Access specialized web3 AI agents for blockchain analysis, smart contract security, token metrics, and blockchain interactions through the [Heurist Mesh network](https://github.com/heurist-network/heurist-agent-framework/tree/main/mesh).
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
-- **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcol actions and growing
 
 ---
 


### PR DESCRIPTION
## New MCP Server: Lightyear CryptoPunks\n\nAdds the Lightyear CryptoPunks MCP server to the Server Implementations list.\n\n**Server details:**\n- **Endpoint:** `https://punks.lightyear.build/api/mcp`\n- **Transport:** Streamable HTTP\n- **Tools:** 11 (browse traits, filter punks, listings, bids, Merkle roots, bid pricing)\n- **Auth:** None — free, rate-limited per IP\n- **Built by:** [Lightyear](https://lightyear.build)\n\nThis is the only MCP server providing direct access to the native CryptoPunks marketplace (the original on-chain market built into the contract itself).