### PR TITLE
Add AgentPay to the list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[AgentPay](https://github.com/romudille-bit/agentpay)** - Pay-per-call crypto data gateway using the x402 protocol. 12 tools including whale tracking, token prices, gas, TVL, Dune queries, Fear & Greed. USDC payments on Stellar (first x402 gateway on Stellar mainnet) and Base. No API keys, hard budget cap.
 
 ---
 


### PR DESCRIPTION
AgentPay is a live x402 payment gateway for AI agents, running on Stellar mainnet and Base mainnet since March 31, 2026.

Agents pay per call in USDC — no API keys, no subscriptions, no manual approvals. The gateway handles the full 402 flow: challenge → on-chain payment → retry → data returned. A budget-aware Session caps total spend so agents can't overspend.

12 tools live: token prices, whale activity, gas tracker, DeFi TVL, Fear & Greed index, Dune Analytics queries, DEX liquidity, funding rates, yield scanner, token security, wallet balance, and crypto news sentiment.

First x402 gateway live on Stellar mainnet. First mainnet tx: https://stellar.expert/explorer/public/tx/29f59465cfed5620