### PR TITLE
feat: Add Everstake MCP to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
-- **[Everstake MCP](https://mcp.everstake.one)** - Non-custodial staking across 130+ networks for asset managers and custodians.
+- **[Everstake MCP](https://mcp.everstake.com)** - Non-custodial staking across 130+ networks for asset managers and custodians.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[Everstake MCP](https://mcp.everstake.one)** - Non-custodial staking across 130+ networks for asset managers and custodians.
 
 ---
 


### PR DESCRIPTION
## Summary                                                                                                                
                                                         
  - Adds **[Everstake MCP](https://mcp.everstake.com)** to the Server Implementations list                                  
  - Non-custodial staking data across 130+ networks for asset managers and custodians                                       
  - Everstake is one of the largest non-custodial staking providers globally                                                
                                                         
  ## What it does                                                                                                         

  The Everstake MCP provides:                                                                                               
  - Real-time staking data across 130+ blockchain networks
  - Validator information and performance metrics                                                                           
  - Staking rewards tracking and analytics               
  - Designed for asset managers and institutional custodians                                                              

  ## Links

  - MCP Server: https://mcp.everstake.com                                                                                   
  - Everstake: https://everstake.com