### PR TITLE
Add AgentRadar Verify — trust oracle for ERC-8004 + x402 agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[AgentRadar Verify](https://github.com/Bichev/agentradar-mcp)** - On-chain trust oracle for the ERC-8004 + x402 agent economy. 18 MCP tools for verifying AI agents: 6-signal trust scoring, 272-wallet scam database, EAS attestations on Base mainnet, x402-payable. Live at [vvpro.ai](https://vvpro.ai). ([npm](https://www.npmjs.com/package/@agentradar/mcp))
 
 ---
 


### PR DESCRIPTION
AgentRadar Verify is an on-chain trust oracle for AI agents on Base mainnet.

What it does: 18 MCP tools to verify AI agents before transacting with them.
- 6 independent signals (ERC-8004 identity, scam DB, fidelity, reputation, health, external)
- Composite trust score 0-100 with risk flags
- Writes EAS attestations on Base mainnet for high-confidence scores
- x402-payable on-chain ($0.005 per fresh verify, $5 per attestation)
- 272-wallet scam database (OFAC SDN, x402 honeypots, ClawHavoc IOCs)

Live at https://vvpro.ai · npm @agentradar/mcp · Listed on Official MCP Registry as io.github.Bichev/agentradar.

Happy to adjust placement / wording — thanks for maintaining this list!