### PR TITLE
Add MainStreet — reputation oracle for Base AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
 
+- **[MainStreet](https://github.com/philpof102-svg/avisradar)** - Reputation oracle for onchain AI agents on Base. Vet any wallet/token before x402 payments via `mainstreet_preflight` → BLOCK/CAUTION/PROCEED in <100ms with EIP-712 signatures. Covers Virtuals agents, Clanker tokens, DEX launches, DexScreener trending, sniper detection. ERC-8004 registered (agentId 53953). `npx -y @raskhaaa/mainstreet-oracle mainstreet-mcp`
+
 ---
 
 Crafted by [Magnet Labs](https://magnetlabs.xyz) with our vibrant AI & Crypto community


### PR DESCRIPTION
Trust oracle for onchain AI agents on Base. Vet wallet/token via mainstreet_preflight before x402 payments. ERC-8004 registered. Free MCP server: npx -y @raskhaaa/mainstreet-oracle mainstreet-mcp