### PR TITLE
docs: add twzrd-agent-intel to Server Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel)** - Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid trust ($0.05) + market intel ($0.03). Hosted MCP at `https://intel.twzrd.xyz/mcp` (streamable-http). Also via PyPI: `pip install twzrd-agent-intel`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
-- **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel)** - Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid trust ($0.05) + market intel ($0.03). Hosted MCP at `https://intel.twzrd.xyz/mcp` (streamable-http). Also via PyPI: `pip install twzrd-agent-intel`.
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid trust ($0.05) + market intel ($0.03). Hosted MCP at `https://intel.twzrd.xyz/mcp` (streamable-http). Also via PyPI: `pip install twzrd-agent-intel`.
 
 ---
 


### PR DESCRIPTION
Add **TWZRD Agent Intel** — Solana agent trust scoring via x402 micropayments.

- Free tools: preflight readiness check, score lookup, top-agents leaderboard, receipt verification
- Paid tools: trust score ($0.05), market intel ($0.03), in USDC on Solana mainnet  
- Hosted MCP endpoint: `https://intel.twzrd.xyz/mcp` (streamable-http, no API key needed)
- PyPI: `pip install twzrd-agent-intel`
- Returns portable `twzrd.receipt.v5` (Ed25519-signed, offline-verifiable)
- Listed on: official MCP Registry, Smithery (quality 98), mcp.so, mcpservers.org

GitHub: https://intel.twzrd.xyz