### PR TITLE
feat: add TWZRD Agent Intel to crypto MCP list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana-native x402 MCP for agent trust scoring and identity verification. 4 free preflight tools score any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior); 4 paid tools return signed `twzrd.receipt.v5` trust tokens via HTTP 402 + USDC on Solana (<1s settlement). MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`.
 
 ---
 


### PR DESCRIPTION
Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** alongside Solana Agent Kit and other Solana-focused MCP servers.

**What it does**: Solana-native agent trust scoring via x402 micropayments — the first Solana-native MCP server for agent identity verification.

- **4 free tools**: Score any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior)
- **4 paid tools**: HTTP 402 + USDC on Solana (<1s settlement) → signed `twzrd.receipt.v5` trust tokens
- **Endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)
- **MCP Registry**: `xyz.twzrd.intel/twzrd-agent-intel`

Placed after Solana Agent Kit as a natural Solana companion.