### PR TITLE
Add AgentsCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[AgentsCoin](https://github.com/axiosdevs/agentscoin-mcp)** - Gives an AI agent its own money on a live EVM chain, letting it create a wallet, mine AGENT, send funds, and create or trade tokens via `npx agentscoin-mcp`.
 
 ---
 


### PR DESCRIPTION
Adds **AgentsCoin** to the Server Implementations section.

AgentsCoin is an MCP server that gives an AI agent its own money on a live EVM chain: the agent can create a wallet, mine AGENT, send funds, and create or trade tokens. Run it with `npx agentscoin-mcp` (also available as a remote server at https://agents-coin.com/mcp).

Repo: https://github.com/axiosdevs/agentscoin-mcp

One entry, added in the existing list format.