### PR TITLE
Add Santiment (official MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome [Model Context Protocol](https://modelcontextprotocol.
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[GOAT](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** - Run more than +200 onchain actions on any blockchain including Ethereum, Solana and Base.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
+- **[Santiment](https://github.com/santiment/sanbase2/blob/master/docs/mcp-connector.md)** - Official Santiment MCP server — behavior analytics for crypto: on-chain metrics, social sentiment, trending narratives, and analyst insights via a remote HTTP endpoint.
 
 ---
 


### PR DESCRIPTION
Adds the official Santiment MCP server. Santiment is a behavior analytics platform for crypto; the server exposes metrics discovery, timeseries data, asset screening, trend detection, and analyst insights over a remote HTTP endpoint (https://api.santiment.net/mcp) with OAuth 2.0. Open source in the Santiment backend (https://github.com/santiment/sanbase2/tree/master/lib/sanbase/mcp). Listed in the official MCP registry as io.github.santiment/santiment-mcp. Docs: https://academy.santiment.net/mcp-connector/